### PR TITLE
不要なバックスラッシュの削除&windowsのパスに変換する際は、文字コードをUTF8に変換

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,14 +1,11 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Web site created using create-react-app"
-    />
+    <meta name="description" content="Web site created using create-react-app" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
@@ -24,7 +21,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>パス変換</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,8 +34,12 @@ export const App = () => {
         .slice(1);
       setPath((prevState) => ({ ...prevState, macPath }));
     } else if (path.macPath) {
+      //パスの変換前に不要なバックスラッシュを削除する
+      const replaceBackSlash = path.macPath.replace(/\\/g, '');
       //macのpathを変換
-      const winPath = `\\${path.macPath.replace(/\//g, '\\').replace(/Volumes/g, '192.168.254.6')}`;
+      const normalizWinPath = `\\${replaceBackSlash.replace(/\//g, '\\').replace(/Volumes/g, '192.168.254.6')}`;
+      //文字コードをUTF8-mac(NFD)からUTF8(NFC)に変換する
+      const winPath = normalizWinPath.normalize('NFC');
       setPath((prevState) => ({ ...prevState, winPath }));
     } else {
       alert('パスを入力してください');


### PR DESCRIPTION
1. 不要なバックスラッシュの削除
- macからwindowsのパスに変換を行う前に、入力されたmacのパス内に不要なバックスラッシュを削除する処理を追加
2. windowsのパスに変換する際は、文字コードをUTF8に変換
- windowsのパスに変換後に、変換した文字列の文字コードをUTF8(NFC)に変換する処理を追加

close #4